### PR TITLE
Drown vulnerabiltiy attributes added to endpoint_details

### DIFF
--- a/lib/ssllabs/endpoint_details.rb
+++ b/lib/ssllabs/endpoint_details.rb
@@ -36,7 +36,10 @@ module Ssllabs
       :rc4Only,
       :preloadChecks,
       :forwardSecrecy,
-      :rc4WithModern?
+      :rc4WithModern?,
+      :drownHosts,
+      :drownErrors,
+      :drownVulnerable?
     has_object_ref :sims, SimDetails
     has_fields :heartbleed?,
       :heartbeat?,

--- a/lib/ssllabs/version.rb
+++ b/lib/ssllabs/version.rb
@@ -1,3 +1,3 @@
 module Ssllabs
-  VERSION = "1.11.4"
+  VERSION = "1.11.5"
 end


### PR DESCRIPTION
SSLLabs api changed once again, added support for drown vulnerability attributes
