### PR TITLE
ignore .gem extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ test/dummy/log/*.log
 test/dummy/tmp/
 test/dummy/.sass-cache
 Gemfile.lock
+*.gem


### PR DESCRIPTION
Minor PR which ignores .gem files when gem is build locally.
