### PR TITLE
activesupport 4.x depends on json ~> 1.7

### DIFF
--- a/ssllabs.gemspec
+++ b/ssllabs.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |s|
   s.test_files = Dir["test/**/*"]
 
   s.add_dependency "activesupport", '>= 4.2.0'
-  s.add_dependency "json", '~> 2.0'
+  s.add_dependency "json", '>= 1.7'
   s.add_dependency "net", '~> 0.3'
 end


### PR DESCRIPTION
Fix #27
